### PR TITLE
Issue 002: Load sounds at start to prevent lag

### DIFF
--- a/src/app/models/sounds.enum.ts
+++ b/src/app/models/sounds.enum.ts
@@ -1,0 +1,6 @@
+export enum Sounds {
+    verse1 = 'assets/theme_verse1.mp3',
+    verse2 = 'assets/theme_verse2.mp3',
+    chorus = 'assets/theme_chorus.mp3',
+    end = 'assets/theme_end.mp3'
+}

--- a/src/app/services/sound.service.ts
+++ b/src/app/services/sound.service.ts
@@ -5,6 +5,7 @@ import { ISubscription } from '../models/subscription.interface';
 import { INextValue } from '../models/next-value.interface';
 import { GameState } from '../models/game-state';
 import { GamePosition } from '../models/game-position.enum';
+import { Sounds } from '../models/sounds.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -13,26 +14,33 @@ export class SoundService implements OnDestroy {
 
   private subscription: ISubscription;
   private rendered: Renderer2;
+  private sounds: Map<Sounds, HTMLAudioElement> = new Map();
   constructor(gameStateService: GameStateService, rendererFactory: RendererFactory2) {
     this.subscription = gameStateService.subscribeToStateChanges(this.handleStateChange);
     this.rendered = rendererFactory.createRenderer(null, null);
+
+    Object.keys(Sounds).forEach((sound: Sounds) => {
+      const audio = this.rendered.createElement('audio') as HTMLAudioElement;
+      audio.src = Sounds[sound];
+      this.sounds.set(Sounds[sound], audio);
+    });
   }
 
   private handleStateChange = async (nextState: INextValue<GameState>): Promise<void> => {
 
     switch (nextState.nextState.position) {
       case GamePosition.pos1:
-        await this.playSound('assets/theme_verse1.mp3');
+        await this.playSound(Sounds.verse1);
         break;
       case GamePosition.pos2:
       case GamePosition.pos4:
-        await this.playSound('assets/theme_chorus.mp3');
+        await this.playSound(Sounds.chorus);
         break;
       case GamePosition.pos3:
-        await this.playSound('assets/theme_verse2.mp3');
+        await this.playSound(Sounds.verse2);
         break;
       case GamePosition.top:
-        await this.playSound('assets/theme_end.mp3');
+        await this.playSound(Sounds.end);
         break;
     }
   }
@@ -41,10 +49,9 @@ export class SoundService implements OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  private async playSound(fileName: string): Promise<void> {
+  private async playSound(sound: Sounds): Promise<void> {
     return new Promise((o) => {
-      const audio = this.rendered.createElement('audio') as HTMLAudioElement;
-      audio.src = fileName;
+      const audio = this.sounds.get(sound);
       audio.play();
       audio.onended = () => {
         o();

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "types": [
       "jest",
     ]


### PR DESCRIPTION
Update sound service to load all audio at the start to prevent lags when
downloading audio over slow networks 

Solves #2 